### PR TITLE
feat: Refactor verify API to use Next.js API routes

### DIFF
--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -1,4 +1,4 @@
-//import { countries, getUserIdentifier, SelfBackendVerifier } from "@selfxyz/core";
+import { NextApiRequest, NextApiResponse } from 'next';
 import { IConfigStorage, VerificationConfig, SelfBackendVerifier, AttestationId } from "@selfxyz/core";
 
 class ConfigStorage implements IConfigStorage {
@@ -14,70 +14,80 @@ class ConfigStorage implements IConfigStorage {
       return "default_config";
     }
 }
+
+// Initialize and configure the verifier
+const IdType = {
+    Passport: 1,
+    EU_ID_Card: 2,
+};
+const allowedIds = new Map();
+allowedIds.set(IdType.Passport, true); // 1 = passport
+allowedIds.set(IdType.EU_ID_Card, true); // 2 = EU ID card (optional)
+
+// Create configuration storage
+const configStorage = new ConfigStorage();
+
+// Initialize the verifier
+const selfBackendVerifier = new SelfBackendVerifier(
+    "finance-3wb-club",                    // Your app's unique scope
+    "https://finance.3wb.club/api/verify",    // The API endpoint of this backend
+    false,                             // false = real passports, true = mock for testing
+    allowedIds,                        // Allowed document types
+    configStorage,                    // Configuration storage implementation
+    "uuid"                  // UUID for off-chain, HEX for on-chain addresses
+);
   
 
-export async function POST(req: Request) {
+export async function POST(req: NextApiRequest, res: NextApiResponse) {
     
     
     try {
-        const { attestationId, proof, pubSignals, userContextData } = await req.json();
-        console.log(attestationId, proof, pubSignals, userContextData);
+        const { attestationId, proof, pubSignals, userContextData } = req.body;
+        console.log("attestationId", attestationId);
+        console.log("proof", proof);
+        console.log("pubSignals", pubSignals);
+        console.log("userContextData", userContextData);
+
 
         if (!proof || !pubSignals) {
             return new Response("Proof and publicSignals are required", { status: 400 });
         }
 
-        // Initialize and configure the verifier
-        const IdType = {
-            Passport: 1,
-            EU_ID_Card: 2,
-        };
+        
 
-        const allowedIds = new Map();
-        allowedIds.set(IdType.Passport, true); // 1 = passport
-        allowedIds.set(IdType.EU_ID_Card, true); // 2 = EU ID card (optional)
-
-        // Create configuration storage
-        const configStorage = new ConfigStorage();
-
-        // Initialize the verifier
-        const selfBackendVerifier = new SelfBackendVerifier(
-            "finance-3wb-club",                    // Your app's unique scope
-            "https://finance.3wb.club/api/verify",    // The API endpoint of this backend
-            false,                             // false = real passports, true = mock for testing
-            allowedIds,                        // Allowed document types
-            configStorage,                    // Configuration storage implementation
-            "uuid"                  // UUID for off-chain, HEX for on-chain addresses
-        );
+       
 
         // Verify the proof
-        const result = await selfBackendVerifier.verify(attestationId as AttestationId, proof, pubSignals, userContextData);
-        console.log("Verification Result:", result);
-        console.log("Credential Subject:", result);
+        const result = await selfBackendVerifier.verify(
+            attestationId,
+            proof,
+            pubSignals,
+            userContextData
+        );
         
         if (result.isValidDetails.isValid) {
             // Return successful verification response
-            
-            return new Response(JSON.stringify({
-                status: "success",
-                result: result.isValidDetails.isValid,
-                credentialSubject: result.userData
-            }), { status: 200 });
+            return res.status(200).json({
+            status: 'success',
+            result: true,
+            credentialSubject: result.discloseOutput
+            });
         } else {
             // Return failed verification response
-            
-            return new Response(JSON.stringify({
-                status: "error",
-                result: result.isValidDetails.isValid,
-                message: "Verification failed",
-                details: result.isValidDetails
-            }), { status: 401 });
+            return res.status(400).json({
+            status: 'error',
+            result: false,
+            message: 'Verification failed',
+            details: result.isValidDetails
+            });
         }
     } catch (error) {
-        console.error("Error verifying proof:", error);
-        return new Response(JSON.stringify({
-            message: "Error verifying proof",
-            error: error instanceof Error ? error.message : "Unknown error"
-        }), { status: 500 });
+          
+        console.error('Error verifying proof:', error);
+        return res.status(500).json({
+            status: 'error',
+            result: false,
+            message: error instanceof Error ? error.message : 'Unknown error'
+        });
     }
 }


### PR DESCRIPTION
Updated the /api/verify endpoint to use NextApiRequest and NextApiResponse from Next.js, replacing the previous Request/Response pattern. Moved verifier initialization outside the handler for efficiency, improved logging, and updated response handling to use res.status().json().