### PR TITLE
feat: Add excludedCountries and ofac to verification config

### DIFF
--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -1,8 +1,12 @@
 import { IConfigStorage, VerificationConfig, SelfBackendVerifier, AttestationId } from "@selfxyz/core";
 
 class ConfigStorage implements IConfigStorage {
-    async getConfig(configId: string) {
-        return {};
+    async getConfig(configId: string): Promise<VerificationConfig> {
+        return {
+            minimumAge: 18,
+            excludedCountries: ["IRN", "USA"],
+            ofac: true,
+        };
     }
   
     async setConfig(id: string, config: VerificationConfig): Promise<boolean> {

--- a/components/kyc/self/qr.tsx
+++ b/components/kyc/self/qr.tsx
@@ -23,6 +23,8 @@ export function QR({ userId }: QRProps) {
         userDefinedData: "0x" + Buffer.from("default").toString('hex').padEnd(128, '0'),
         disclosures: {
             minimumAge: 18,
+            excludedCountries: ["IRN", "USA"],
+            ofac: true,
         }
     }).build();
 


### PR DESCRIPTION
Updated both the API route and QR component to include 'excludedCountries' and 'ofac' fields in the verification configuration. This ensures consistent enforcement of country exclusions and OFAC compliance across the backend and frontend.