### PR TITLE
feat: Update excluded countries in KYC verification

### DIFF
--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -4,7 +4,7 @@ class ConfigStorage implements IConfigStorage {
     async getConfig(configId: string): Promise<VerificationConfig> {
         return {
             minimumAge: 18,
-            excludedCountries: ["IRN", "USA"],
+            excludedCountries: ["USA", "CUB", "IRN", "PRK", "RUS"],
             ofac: true,
         };
     }

--- a/components/kyc/self/qr.tsx
+++ b/components/kyc/self/qr.tsx
@@ -23,7 +23,7 @@ export function QR({ userId }: QRProps) {
         userDefinedData: "0x" + Buffer.from("default").toString('hex').padEnd(128, '0'),
         disclosures: {
             minimumAge: 18,
-            excludedCountries: ["IRN", "USA"],
+            excludedCountries: ["USA", "CUB", "IRN", "PRK", "RUS"],
             ofac: true,
         }
     }).build();


### PR DESCRIPTION
Expanded the list of excluded countries to include CUB, PRK, and RUS in both the verification API and KYC QR component for consistency with compliance requirements.