### PR TITLE
feat: Increase file upload size limit to 4MB

### DIFF
--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -14,7 +14,7 @@ export const ourFileRouter = {
        * For full list of options and defaults, see the File Route API reference
        * @see https://docs.uploadthing.com/file-routes#route-config
        */
-      maxFileSize: "1MB",
+      maxFileSize: "4MB",
       maxFileCount: 2,
     },
   })

--- a/components/kyc/verifyKYC.tsx
+++ b/components/kyc/verifyKYC.tsx
@@ -284,14 +284,14 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                   profile.files.length <= 0
                                   ?(
                                     <>
-                                      <Label className="text-yellow-600">Upload ID <span className="text-xs text-muted-foreground">(must be under 1MB)</span></Label>
+                                      <Label className="text-yellow-600">Upload ID <span className="text-xs text-muted-foreground">(must be under 4MB)</span></Label>
                                       <div>
                                         <FileUploader
                                           value={files}
                                           onValueChange={setFiles}
                                           dropzoneOptions={{
                                             maxFiles: maxFiles!,
-                                            maxSize: 1024 * 1024 * 1,
+                                            maxSize: 1024 * 1024 * 4,
                                             multiple: true,
                                             accept: {
                                               "image/*": [".png", ".jpg", ".jpeg"],
@@ -345,7 +345,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                         {
                           !maxFiles && (
                             <div>
-                            <Label className="text-yellow-600">Upload ID <span className="text-xs text-muted-foreground">(must be under 1MB)</span></Label>
+                            <Label className="text-yellow-600">Upload ID <span className="text-xs text-muted-foreground">(must be under 4MB)</span></Label>
                             <div>
                               <div
                                 className="relative bg-background rounded-lg p-2"


### PR DESCRIPTION
Updated the maximum file size for uploads from 1MB to 4MB in both the backend file router and the KYC verification UI. Adjusted user-facing labels and file uploader configuration to reflect the new limit.