### PR TITLE
Disable autocomplete for KYC input fields

### DIFF
--- a/components/kyc/verifyContact.tsx
+++ b/components/kyc/verifyContact.tsx
@@ -369,7 +369,7 @@ export function VerifyContact({ address, profile, getProfileSync }: VerifyEmailP
                                       <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                       <FormLabel>Enter your email address</FormLabel>
                                           <FormControl >
-                                              <Input disabled={ !!profile || !!email || loadingCode || isDisabledEmail } className="col-span-3" placeholder={""} {...field} />
+                                              <Input autoComplete="off" disabled={ !!profile || !!email || loadingCode || isDisabledEmail } className="col-span-3" placeholder={""} {...field} />
                                           </FormControl>
                                       </div>
                                   </FormItem>
@@ -497,6 +497,7 @@ export function VerifyContact({ address, profile, getProfileSync }: VerifyEmailP
                                 <FormLabel>Enter your phone number</FormLabel>
                                 <FormControl className="w-full">
                                   <PhoneInput
+                                    autoComplete="off"
                                     disabled={ !!profile?.phone || loadingCode || isDisabledPhone } 
                                     placeholder={profile?.phone ? profile.phone : "Enter your phone number"}
                                     className="col-span-3"

--- a/components/kyc/verifyKYC.tsx
+++ b/components/kyc/verifyKYC.tsx
@@ -407,7 +407,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                 <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                     <FormLabel className="text-yellow-600">First Name</FormLabel>
                                     <FormControl >
-                                        <Input disabled={ !!profile.firstname || loading } className="col-span-3" placeholder={profile.firstname ? profile.firstname : "Vitalik"} {...field} />
+                                        <Input autoComplete="off" disabled={ !!profile.firstname || loading } className="col-span-3" placeholder={profile.firstname ? profile.firstname : "Vitalik"} {...field} />
                                     </FormControl>
                                 </div>
                             </FormItem>
@@ -421,7 +421,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                   <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                       <FormLabel className="text-yellow-600">Other Name(s)</FormLabel>
                                       <FormControl >
-                                          <Input disabled={ !!profile.othername || loading } className="col-span-3" placeholder={profile.othername ? profile.othername : "DeSantis"} {...field} />
+                                          <Input autoComplete="off" disabled={ !!profile.othername || loading } className="col-span-3" placeholder={profile.othername ? profile.othername : "DeSantis"} {...field} />
                                       </FormControl>
                                   </div>
                               </FormItem>
@@ -435,7 +435,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                   <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                       <FormLabel className="text-yellow-600">Last Name</FormLabel>
                                       <FormControl >
-                                          <Input disabled={ !!profile.lastname || loading } className="col-span-3" placeholder={profile.lastname ? profile.lastname : "Buterin"} {...field} />
+                                          <Input autoComplete="off" disabled={ !!profile.lastname || loading } className="col-span-3" placeholder={profile.lastname ? profile.lastname : "Buterin"} {...field} />
                                       </FormControl>
                                   </div>
                               </FormItem>
@@ -527,7 +527,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                               <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                                   <FormLabel className="text-yellow-600">First Name</FormLabel>
                                                   <FormControl >
-                                                      <Input disabled={ !!profile.firstname || loading } className="col-span-3" placeholder={profile.firstname ? profile.firstname : "Vitalik"} {...field} />
+                                                      <Input autoComplete="off" disabled={ !!profile.firstname || loading } className="col-span-3" placeholder={profile.firstname ? profile.firstname : "Vitalik"} {...field} />
                                                   </FormControl>
                                               </div>
                                           </FormItem>
@@ -541,7 +541,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                                 <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                                     <FormLabel className="text-yellow-600">Other Name(s)</FormLabel>
                                                     <FormControl >
-                                                        <Input disabled={ !!profile.othername || loading } className="col-span-3" placeholder={profile.othername ? profile.othername : "DeSantis"} {...field} />
+                                                        <Input autoComplete="off" disabled={ !!profile.othername || loading } className="col-span-3" placeholder={profile.othername ? profile.othername : "DeSantis"} {...field} />
                                                     </FormControl>
                                                 </div>
                                             </FormItem>
@@ -555,7 +555,7 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                                 <div className="flex flex-col gap-1 w-full max-w-sm space-x-2">
                                                     <FormLabel className="text-yellow-600">Last Name</FormLabel>
                                                     <FormControl >
-                                                        <Input disabled={ !!profile.lastname || loading } className="col-span-3" placeholder={profile.lastname ? profile.lastname : "Buterin"} {...field} />
+                                                        <Input autoComplete="off" disabled={ !!profile.lastname || loading } className="col-span-3" placeholder={profile.lastname ? profile.lastname : "Buterin"} {...field} />
                                                     </FormControl>
                                                 </div>
                                             </FormItem>


### PR DESCRIPTION
Added autoComplete="off" to email, phone, and name input fields in KYC verification components to prevent browsers from autofilling sensitive user information.