### PR TITLE
feat: Switch KYC userId to hex address and update verifier

### DIFF
--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -37,7 +37,7 @@ const selfBackendVerifier = new SelfBackendVerifier(
     false,                             // false = real passports, true = mock for testing
     allowedIds,                        // Allowed document types
     configStorage,                    // Configuration storage implementation
-    "uuid"                  // UUID for off-chain, HEX for on-chain addresses
+    "hex"                  // UUID for off-chain, HEX for on-chain addresses
 );
   
 

--- a/components/kyc/verifyKYC.tsx
+++ b/components/kyc/verifyKYC.tsx
@@ -54,32 +54,26 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
   const [qr, setQR] = useState<boolean>(false);
   const [upload, setUpload] = useState<boolean>(false);
 
-  const [userId, setUserId] = useState<string | null>(null);
 
-    useEffect(() => {
-        // Generate a user ID when the component mounts
-        setUserId(uuidv4());
-    }, []);
-
-    // Create the SelfApp configuration
-    const selfApp = new SelfAppBuilder({
-      appName: "3 Wheeler Bike Club",
-      scope: "finance-3wb-club",
-      endpoint: "https://finance.3wb.club/api/verify",
-      endpointType: "https",
-      logoBase64: "https://finance.3wb.club/icons/logo.png",
-      userId: userId!,
-      userIdType: "uuid",
-      version: 2,
-      userDefinedData: "0x" + Buffer.from("default").toString('hex').padEnd(128, '0'),
-      disclosures: {
-          name: true,
-          expiry_date: true,
-          nationality: true,
-          minimumAge: 18,
-          excludedCountries: ["USA", "CUB", "IRN", "PRK", "RUS"],
-          ofac: true,
-      }
+  // Create the SelfApp configuration
+  const selfApp = new SelfAppBuilder({
+    appName: "3 Wheeler Bike Club",
+    scope: "finance-3wb-club",
+    endpoint: "https://finance.3wb.club/api/verify",
+    endpointType: "https",
+    logoBase64: "https://finance.3wb.club/icons/logo.png",
+    userId: address,
+    userIdType: "hex",
+    version: 2,
+    userDefinedData: "0x" + Buffer.from("default").toString('hex').padEnd(128, '0'),
+    disclosures: {
+        name: true,
+        expiry_date: true,
+        nationality: true,
+        minimumAge: 18,
+        excludedCountries: ["USA", "CUB", "IRN", "PRK", "RUS"],
+        ofac: true,
+    }
   }).build();
 
   const { startUpload, routeConfig } = useUploadThing("imageUploader", {


### PR DESCRIPTION
Replaces the use of a generated UUID with the user's hex address for the KYC process in both the backend verifier and the SelfApp configuration. This aligns user identification with on-chain address standards and ensures consistency between frontend and backend.