### PR TITLE
feat: Update fleetOrderBook contract address

### DIFF
--- a/utils/constants/addresses.tsx
+++ b/utils/constants/addresses.tsx
@@ -1,5 +1,5 @@
 export const cUSD: `0x${string}` = "0x765de816845861e75a25fca122bb6898b8b1282a";
 export const USDT: `0x${string}` = "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e";
 export const USDT_ADAPTER: `0x${string}` = "0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72";
-export const fleetOrderBook: `0x${string}` = "0xF4Aa5bEaDbE8368a59B9c25Fc7Ff9C6954C3A807";
+export const fleetOrderBook: `0x${string}` = "0xc16c3BFf7c1B1a92cF0A6bbF2a0508fb5B4da00E";
 export const divvi: `0x${string}` = "0xEdb51A8C390fC84B1c2a40e0AE9C9882Fa7b7277";


### PR DESCRIPTION
Changed the fleetOrderBook constant to use the new contract address. This ensures the application interacts with the correct deployed contract.