### PR TITLE
feat: Send verification pending email after KYC submission

### DIFF
--- a/app/actions/mail/sendVerifySelfMail.ts
+++ b/app/actions/mail/sendVerifySelfMail.ts
@@ -1,0 +1,47 @@
+"use server"
+
+
+import nodemailer from "nodemailer"
+
+export const sendVerifySelfMail = async (email: string, name: string) => {
+
+
+    try {
+        const transporter = nodemailer.createTransport({
+            host: "smtppro.zoho.com",
+            port: 465,
+            secure: true, // Use `true` for port 465, `false` for all other ports
+            auth: {
+                user: process.env.FINANCE_3WB_USER,
+                pass: process.env.FINANCE_3WB_PASS,
+            },
+        });
+    
+        const verifyPendingEmail = {
+            from: `Finance @ 3wb.club <${process.env.FINANCE_3WB_USER}>`,
+            to: email, // Dynamic recipient email address
+            subject: "Your verification is pending team review",
+            html: `
+                <p>Hi ${name},</p>
+
+                <p>Your verification is pending team review. Please note that this process may take 24-48 hours to complete.</p>
+
+                <p>We will notify you once your verification has been reviewed. In the meantime, please standby for updates.</p>
+
+                <p>If you have any questions or concerns, feel free to reach out to our support team.</p>
+
+                <p>Warm regards,<br/>3wb.club</p>
+            `,
+        };
+        const result = await transporter.sendMail(verifyPendingEmail);
+        console.log(result);
+        if(result.accepted) {
+            return true;
+        }
+    } catch (error) {
+        console.log(error)
+    }
+
+}
+
+

--- a/components/kyc/verifyKYC.tsx
+++ b/components/kyc/verifyKYC.tsx
@@ -6,7 +6,7 @@ import { z } from "zod"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button } from "@/components/ui/button"
-import { Camera, CloudUpload, FileWarning, Hourglass, Loader2, Paperclip, Save, SaveAll, Scan, Undo2 } from "lucide-react"
+import { Camera, CloudUpload, FileWarning, Hourglass, Loader2, Paperclip, Save, Scan, Undo2 } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
@@ -17,8 +17,8 @@ import { useUploadThing } from "@/hooks/useUploadThing"
 import { updateProfileAction } from "@/app/actions/kyc/updateProfileAction"
 import { Profile } from "@/hooks/useGetProfile"
 import { Label } from "../ui/label"
-import { v4 as uuidv4 } from 'uuid';
 import { SelfAppBuilder, SelfQRcode } from "@selfxyz/qrcode"
+import { sendVerifySelfMail } from "@/app/actions/mail/sendVerifySelfMail"
 
   
 
@@ -151,6 +151,10 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
               uploadFiles.map((file) => file.ufsUrl)
             );
             if (updateProfile) {
+              await sendVerifySelfMail(
+                profile.email,
+                manualFormValues.firstname
+              )
               toast.success("KYC Completed", {
                 description: "Our Team will review your KYC and get back to you shortly",
               })
@@ -530,6 +534,10 @@ export function VerifyKYC({ address, profile, getProfileSync }: VerifyKYCProps) 
                                           []
                                         );
                                         if (updateProfile) {
+                                          await sendVerifySelfMail(
+                                            profile.email,
+                                            values.firstname
+                                          )
                                           toast.success("KYC Completed", {
                                             description: "Our Team will review your KYC and get back to you shortly",
                                           })


### PR DESCRIPTION
Introduces sendVerifySelfMail utility using nodemailer to notify users that their KYC verification is pending team review. Integrates email sending into KYC completion flows in verifyKYC.tsx to improve user communication.