### PR TITLE
feat: Update login and logout to use Privy hooks with callbacks

### DIFF
--- a/components/landing/wrapper.tsx
+++ b/components/landing/wrapper.tsx
@@ -5,13 +5,17 @@ import { useRouter } from "next/navigation";
 import { Button } from "../ui/button";
 import { Wallet, TrendingUp, ShieldCheck, ChartNoAxesCombined } from "lucide-react";
 import Image from "next/image";
-import { usePrivy } from "@privy-io/react-auth";
+import { usePrivy, useLogin } from "@privy-io/react-auth";
 
 export function Wrapper() {
 
-    const { ready, authenticated, login } = usePrivy()
+    const { ready, authenticated } = usePrivy()
     const router = useRouter()
-
+    const { login } = useLogin({
+        onComplete: () => {
+            router.push("/fleet")
+        }
+    })
 
     
     async function Login() {

--- a/components/top/logout.tsx
+++ b/components/top/logout.tsx
@@ -13,10 +13,16 @@ import {
 import { Button } from "../ui/button"
 import { LogOut } from "lucide-react"
 import { useDisconnect } from "wagmi"
+import { useLogout } from "@privy-io/react-auth"
 
 export function Logout () {
-    
-    const { disconnect } = useDisconnect()
+    const { logout } = useLogout({
+        onSuccess: () => {
+            console.log('User successfully logged out');
+            // Redirect to landing page or perform other post-logout actions
+            router.push("/")
+        }
+    })
     const router = useRouter()
 
     
@@ -41,8 +47,7 @@ export function Logout () {
                 <AlertDialogAction asChild>
                     <Button
                         onClick={async ()=>{
-                            disconnect()
-                            router.push("/")
+                            logout()
                         }}
                         className="gap-2"
                     >


### PR DESCRIPTION
Refactored the landing wrapper to use useLogin from @privy-io/react-auth with an onComplete callback for post-login navigation. Updated the logout component to use useLogout with an onSuccess callback for post-logout actions, replacing direct disconnect and navigation logic.