### PR TITLE
feat: Split Next.js config for dev and production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
+const NextConfigDevelopment: NextConfig = {}
+
+const NextConfigProduction: NextConfig = {
   async headers() {
     return [
       {
@@ -27,8 +29,8 @@ const nextConfig: NextConfig = {
           },
         ],
       },
-    ];
+    ];  
   },
 };
 
-export default nextConfig;
+export default process.env.NODE_ENV === "production" ? NextConfigProduction : NextConfigDevelopment;


### PR DESCRIPTION
Separated Next.js configuration into development and production variants. The production config includes custom headers, while the development config is currently empty. The default export now selects the appropriate config based on NODE_ENV.