### PR TITLE
feat: Refactor to use Privy for user authentication

### DIFF
--- a/components/fleet/buy/wrapper.tsx
+++ b/components/fleet/buy/wrapper.tsx
@@ -14,8 +14,7 @@ import {
 } from "@/components/ui/drawer"
 import { useEffect, useState } from "react"
 import Image from "next/image"
-import { motion } from "framer-motion"
-import { BanknoteArrowDown, ChartPie, Ellipsis, HandCoins, Loader2, Minus, Plus, RefreshCw, Signature } from "lucide-react";
+import { BanknoteArrowDown, ChartPie, HandCoins, Loader2, Minus, Plus, RefreshCw, Signature } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { divvi, fleetOrderBook, cUSD } from "@/utils/constants/addresses";
@@ -30,11 +29,17 @@ import { useSendTransaction } from "wagmi";
 import { publicClient } from "@/utils/client";
 import { useSwitchChain } from "wagmi";
 import { OnRamp } from "./onRamp";
+import { usePrivy } from "@privy-io/react-auth";
 
 
 export function Wrapper() {
 
-    const { address, chainId } = useAccount()
+    const { user } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
+    
+    const { chainId } = useAccount()
     const { switchChainAsync } = useSwitchChain()
     console.log(chainId)
 

--- a/components/fleet/garage.tsx
+++ b/components/fleet/garage.tsx
@@ -4,7 +4,7 @@ import { Caravan, HandCoins, OctagonMinus, Warehouse } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Button } from "../ui/button";
 
-import { useBlockNumber, useReadContract, useAccount } from 'wagmi'
+import { useBlockNumber, useReadContract } from 'wagmi'
 import { useRouter } from "next/navigation";
 import { fleetOrderBook } from "@/utils/constants/addresses";
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook";
@@ -16,6 +16,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Progress } from "../ui/progress";
 import { Returns } from "./withdraw/returns";
+import { usePrivy } from "@privy-io/react-auth";
 
 
 export function Garage() {
@@ -40,7 +41,10 @@ export function Garage() {
     }, [api])
 
     
-    const { address, isConnected } = useAccount()
+    const { user, ready, authenticated } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
 
     const fleetOwnedQueryClient = useQueryClient() 
     const maxFleetOrderQueryClient = useQueryClient() 
@@ -140,7 +144,7 @@ export function Garage() {
                         <div/>
                         <div className="flex gap-2">
                             <Button 
-                                disabled={!isConnected}
+                                disabled={!ready || !authenticated}
                                 className="max-w-fit h-12 rounded-xl"
                                 onClick={() => router.push(`/fleet/buy`)}
                             >

--- a/components/fleet/history/logs.tsx
+++ b/components/fleet/history/logs.tsx
@@ -10,19 +10,22 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer"
-import { Button } from "../../ui/button";
+import { Button } from "@/components/ui/button";
 import { HistoryIcon } from "lucide-react";
 import { useGetLogs } from "@/hooks/useGetLogs";
-import { Table, TableBody, TableCaption } from "../../ui/table";
+import { Table, TableBody } from "@/components/ui/table";
 import { Log } from "./log";
-import { useAccount } from "wagmi";
+import { usePrivy } from "@privy-io/react-auth";
 
 
 
 
 export function Logs() {
 
-   const { address } = useAccount()
+   const { user } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
 
    const { logs } = useGetLogs(address);
    console.log(logs)

--- a/components/fleet/id.tsx
+++ b/components/fleet/id.tsx
@@ -3,11 +3,12 @@ import { CarouselItem } from "../ui/carousel"
 import { CardContent } from "../ui/card"
 import { Card } from "../ui/card"
 import Image from "next/image"
-import { useBlockNumber, useReadContract, useAccount } from "wagmi"
+import { useBlockNumber, useReadContract } from "wagmi"
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook"
 import { fleetOrderBook } from "@/utils/constants/addresses"
 import { useQueryClient } from "@tanstack/react-query"
 import { useEffect } from "react"
+import { usePrivy } from "@privy-io/react-auth"
 
 
 
@@ -17,7 +18,10 @@ interface IdProps {
 
 export function Id( {fleet}: IdProps ) {    
 
-    const { address } = useAccount()
+    const { user } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
 
     const isfleetFractionedQueryClient = useQueryClient()
     const fleetSharesQueryClient = useQueryClient()

--- a/components/fleet/withdraw/returns.tsx
+++ b/components/fleet/withdraw/returns.tsx
@@ -11,14 +11,17 @@ import {
 } from "@/components/ui/drawer"
 import { Button } from "../../ui/button";
 import { BanknoteArrowUp } from "lucide-react";
-import { useAccount } from "wagmi";
+import { usePrivy } from "@privy-io/react-auth";
 
 
 
 
 export function Returns() {
     
-    const { address } = useAccount()
+    const { user } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
 
 
 

--- a/components/fleet/wrapper.tsx
+++ b/components/fleet/wrapper.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useAccount, useBlockNumber, useReadContract } from "wagmi"
+import { useBlockNumber, useReadContract } from "wagmi"
 import { fleetOrderBook } from "@/utils/constants/addresses"
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook"
 import { useQueryClient } from "@tanstack/react-query"
@@ -8,11 +8,16 @@ import { useEffect } from "react"
 import { Garage } from "./garage"
 import { Menu } from "@/components/top/menu"
 import { useRouter } from "next/navigation"
+import { usePrivy } from "@privy-io/react-auth"
 
 
 export function Wrapper() {
 
-    const { address } = useAccount()
+    const { user } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
+    
     const router = useRouter()
 
 
@@ -45,7 +50,7 @@ export function Wrapper() {
         <div className="flex flex-col h-full p-4 md:p-6 lg:p-8 w-full gap-6">
             <Menu/>
             {
-                compliantLoading
+                compliantLoading 
                 ? (
                     <div className="flex h-full justify-center items-center text-2xl font-bold">
                         <p>Loading...</p>

--- a/components/kyc/wrapper.tsx
+++ b/components/kyc/wrapper.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useAccount, useBlockNumber, useReadContract } from "wagmi"
+import { useBlockNumber, useReadContract } from "wagmi"
 import { fleetOrderBook } from "@/utils/constants/addresses"
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook"
 import { useQueryClient } from "@tanstack/react-query"
@@ -8,16 +8,21 @@ import { useEffect } from "react"
 import { Menu } from "@/components/top/menu"
 import { useRouter } from "next/navigation"
 import { useGetProfile } from "@/hooks/useGetProfile"
-import { Alert, AlertDescription, AlertTitle } from "../ui/alert"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { DoorOpen, UserRoundSearch } from "lucide-react"
 import { VerifyKYC } from "./verifyKYC"
 import { VerifyContact } from "./verifyContact"
+import { usePrivy } from "@privy-io/react-auth"
 
 
 
 export function Wrapper() {
 
-    const { address } = useAccount()
+    const { user } = usePrivy()
+    console.log(user)
+    console.log(user?.wallet?.address)
+    const address = user?.wallet?.address as `0x${string}`
+    
     const { profile, loading, getProfileSync } = useGetProfile(address!)
     console.log(profile);
     const router = useRouter()  


### PR DESCRIPTION
Replaced usage of wagmi's useAccount hook with usePrivy from @privy-io/react-auth across multiple fleet and kyc components. User address is now accessed via Privy, improving authentication consistency and preparing for enhanced user management.