### PR TITLE
feat: Update dependencies for Privy, wagmi, and related packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@divvi/referral-sdk": "^1.0.0",
         "@hookform/resolvers": "^5.1.1",
-        "@privy-io/react-auth": "^2.21.2",
+        "@privy-io/react-auth": "^2.21.3",
+        "@privy-io/wagmi": "^1.0.6",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -24,7 +25,7 @@
         "@radix-ui/react-switch": "^1.2.4",
         "@selfxyz/core": "^1.0.7-beta.1",
         "@selfxyz/qrcode": "^1.0.10-beta.1",
-        "@tanstack/react-query": "^5.76.1",
+        "@tanstack/react-query": "^5.85.3",
         "@tanstack/react-table": "^8.21.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/nodemailer": "^6.4.17",
@@ -53,7 +54,7 @@
         "uploadthing": "^7.7.2",
         "vaul": "^1.1.2",
         "viem": "^2.29.4",
-        "wagmi": "^2.15.4",
+        "wagmi": "^2.16.3",
         "zod": "^3.25.64"
       },
       "devDependencies": {
@@ -100,9 +101,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -228,9 +229,9 @@
       "license": "MIT"
     },
     "node_modules/@ecies/ciphers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.3.tgz",
-      "integrity": "sha512-tapn6XhOueMwht3E2UzY0ZZjYokdaw9XtL9kEyjhQ/Fb9vL9xTFbOaI+fV0AWvTpYu4BNloC6getKW6NtSg4mA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.4.tgz",
+      "integrity": "sha512-t+iX+Wf5nRKyNzk8dviW3Ikb/280+aEJAnw9YXvCp2tYGPSkMki+NRY+8aNLmVFv3eNtMdvViPNOPxS8SZNP+w==",
       "license": "MIT",
       "engines": {
         "bun": ">=1",
@@ -1346,6 +1347,19 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
+    "node_modules/@gemini-wallet/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gemini-wallet/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-97Ktv+vZszADHdu6hS/B5tRfOqebwGNyD2Pfvmo1kK8d54UsNZtC22D8LJEueXqgVbq5PeSn0jv88uav3t1fHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/rpc-errors": "7.0.2",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "viem": ">=2.0.0"
+      }
+    },
     "node_modules/@headlessui/react": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.7.tgz",
@@ -2088,6 +2102,39 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/rpc-errors": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-6.4.0.tgz",
+      "integrity": "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/utils": "^9.0.0",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@metamask/eth-sig-util": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-6.0.2.tgz",
@@ -2115,6 +2162,39 @@
         "@metamask/rpc-errors": "^6.2.1",
         "@metamask/safe-event-emitter": "^3.0.0",
         "@metamask/utils": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@metamask/json-rpc-engine/node_modules/@metamask/rpc-errors": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-6.4.0.tgz",
+      "integrity": "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/utils": "^9.0.0",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@metamask/json-rpc-engine/node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2220,6 +2300,39 @@
         "node": "^18.18 || >=20"
       }
     },
+    "node_modules/@metamask/providers/node_modules/@metamask/rpc-errors": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-6.4.0.tgz",
+      "integrity": "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/utils": "^9.0.0",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@metamask/providers/node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@metamask/providers/node_modules/@metamask/utils": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-8.5.0.tgz",
@@ -2241,22 +2354,22 @@
       }
     },
     "node_modules/@metamask/rpc-errors": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-6.4.0.tgz",
-      "integrity": "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.2.tgz",
+      "integrity": "sha512-YYYHsVYd46XwY2QZzpGeU4PSdRhHdxnzkB8piWGvJW2xbikZ3R+epAYEL4q/K8bh9JPTucsUdwRFnACor1aOYw==",
       "license": "MIT",
       "dependencies": {
-        "@metamask/utils": "^9.0.0",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^18.20 || ^20.17 || >=22"
       }
     },
     "node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
-      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.4.2.tgz",
+      "integrity": "sha512-TygCcGmUbhmpxjYMm+mx68kRiJ80jYV54/Aa8gUFBv4cTX7ulX2XZKr8CJoJAw3K3FN5ZvCRmU0IzWZFaonwhA==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -2265,12 +2378,13 @@
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
         "debug": "^4.3.4",
+        "lodash.memoize": "^4.1.2",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^18.18 || ^20.14 || >=22"
       }
     },
     "node_modules/@metamask/safe-event-emitter": {
@@ -2308,15 +2422,7 @@
         "uuid": "^8.3.2"
       }
     },
-    "node_modules/@metamask/sdk-install-modal-web": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@metamask/sdk-install-modal-web/-/sdk-install-modal-web-0.32.0.tgz",
-      "integrity": "sha512-TFoktj0JgfWnQaL3yFkApqNwcaqJ+dw4xcnrJueMP3aXkSNev2Ido+WVNOg4IIMxnmOrfAC9t0UJ0u/dC9MjOQ==",
-      "dependencies": {
-        "@paulmillr/qr": "^0.2.1"
-      }
-    },
-    "node_modules/@metamask/sdk/node_modules/@metamask/sdk-communication-layer": {
+    "node_modules/@metamask/sdk-communication-layer": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.32.0.tgz",
       "integrity": "sha512-dmj/KFjMi1fsdZGIOtbhxdg3amxhKL/A5BqSU4uh/SyDKPub/OT+x5pX8bGjpTL1WPWY/Q0OIlvFyX3VWnT06Q==",
@@ -2333,6 +2439,23 @@
         "eventemitter2": "^6.4.9",
         "readable-stream": "^3.6.2",
         "socket.io-client": "^4.5.1"
+      }
+    },
+    "node_modules/@metamask/sdk-communication-layer/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/sdk-install-modal-web": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@metamask/sdk-install-modal-web/-/sdk-install-modal-web-0.32.0.tgz",
+      "integrity": "sha512-TFoktj0JgfWnQaL3yFkApqNwcaqJ+dw4xcnrJueMP3aXkSNev2Ido+WVNOg4IIMxnmOrfAC9t0UJ0u/dC9MjOQ==",
+      "dependencies": {
+        "@paulmillr/qr": "^0.2.1"
       }
     },
     "node_modules/@metamask/sdk/node_modules/cross-fetch": {
@@ -2701,15 +2824,11 @@
       }
     },
     "node_modules/@privy-io/api-base": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@privy-io/api-base/-/api-base-1.5.2.tgz",
-      "integrity": "sha512-0eJBoQNmCSsWSWhzEVSU8WqPm7bgeN6VaAmqeXvjk8Ni0jM8nyTYjmRAqiCSs3mRzsnlQVchkGR6lsMTHkHKbw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/api-base/-/api-base-1.6.0.tgz",
+      "integrity": "sha512-ftlqjFw0Ww7Xn6Ad/1kEUsXRfKqNdmJYKat4ryJl2uPh60QXXlPfnf4y17dDFHJlnVb7qY10cCvKVz5ev5gAeg==",
       "dependencies": {
         "zod": "^3.24.3"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
       }
     },
     "node_modules/@privy-io/chains": {
@@ -2728,9 +2847,9 @@
       }
     },
     "node_modules/@privy-io/js-sdk-core": {
-      "version": "0.53.3",
-      "resolved": "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.53.3.tgz",
-      "integrity": "sha512-mppi9UA1ibzQ0WZuO8LKgEvjA6yRrhtVDVg47ci62u/+a3fkUM22Wg4d4LWidpN6JD4acnqtPW5oK2dNWYX2aw==",
+      "version": "0.53.4",
+      "resolved": "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.53.4.tgz",
+      "integrity": "sha512-ObiyekURx9RAHsyL/NqwIDrMhl98ozBlHyEKD59yaUeZxP+wSuwWO59VgtvPUp0F1JAkg4N0aP7MdP6Cz7KBFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -2739,9 +2858,9 @@
         "@ethersproject/providers": "^5.7.2",
         "@ethersproject/transactions": "^5.7.0",
         "@ethersproject/units": "^5.7.0",
-        "@privy-io/api-base": "1.5.2",
+        "@privy-io/api-base": "1.6.0",
         "@privy-io/chains": "0.0.2",
-        "@privy-io/public-api": "2.43.0",
+        "@privy-io/public-api": "2.43.1",
         "canonicalize": "^2.0.0",
         "eventemitter3": "^5.0.1",
         "fetch-retry": "^6.0.0",
@@ -2765,12 +2884,12 @@
       }
     },
     "node_modules/@privy-io/public-api": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/@privy-io/public-api/-/public-api-2.43.0.tgz",
-      "integrity": "sha512-fVklVUKQlJN/9bpBKAf0YSOJ1tEpjFL7cI4wxTgLy0298ODYFXf303UiZFk5d1MNtLUobamYRncFQLZ3aMf1iw==",
+      "version": "2.43.1",
+      "resolved": "https://registry.npmjs.org/@privy-io/public-api/-/public-api-2.43.1.tgz",
+      "integrity": "sha512-zhGBTghZiwnqdA4YvrXXM7fsz3fWUltSkxNdnQTqKGb/IfV8aZ14ryuWvD4v5oPJGtqVcwKRfdDmW8TMPGZHog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@privy-io/api-base": "1.5.2",
+        "@privy-io/api-base": "1.6.0",
         "bs58": "^5.0.0",
         "libphonenumber-js": "^1.10.31",
         "viem": "^2",
@@ -2793,9 +2912,9 @@
       }
     },
     "node_modules/@privy-io/react-auth": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-2.21.2.tgz",
-      "integrity": "sha512-dLPbdMCrN/85DGsHdXwBXLq/KAv9rubNPvZWWWBG30OR/Y6YSjidxcapCcDFcxrVrsHQYgpfHCZ72Y94QwUayA==",
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-2.21.3.tgz",
+      "integrity": "sha512-qgQaEf0WDyzw7I/z2tbABikEj3DgQKP0rN4iooU8dKxW9oDOssBOoa+NVXCHcC8ikAk4Q36Gd6fOw362IAxswA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-org/account": "^1.1.0",
@@ -2805,11 +2924,11 @@
         "@heroicons/react": "^2.1.1",
         "@marsidev/react-turnstile": "^0.4.1",
         "@metamask/eth-sig-util": "^6.0.0",
-        "@privy-io/api-base": "1.5.2",
+        "@privy-io/api-base": "1.6.0",
         "@privy-io/chains": "0.0.2",
         "@privy-io/ethereum": "0.0.2",
-        "@privy-io/js-sdk-core": "0.53.3",
-        "@privy-io/public-api": "2.43.0",
+        "@privy-io/js-sdk-core": "0.53.4",
+        "@privy-io/public-api": "2.43.1",
         "@reown/appkit": "^1.7.11",
         "@scure/base": "^1.2.5",
         "@simplewebauthn/browser": "^9.0.1",
@@ -2931,6 +3050,17 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@privy-io/wagmi": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@privy-io/wagmi/-/wagmi-1.0.6.tgz",
+      "integrity": "sha512-FG9Kk4tXC7VyXOMsf4JmnhLjwdDm6so5WDouhmuLzCd6nbY0SeO88HI3QeXuUo7WeavM1CA7YSYO7p3GQbCg/g==",
+      "peerDependencies": {
+        "@privy-io/react-auth": "^2.0.0",
+        "react": ">=18",
+        "viem": "^2.30.6",
+        "wagmi": "^2.15.5"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5665,9 +5795,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.76.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
-      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.3.tgz",
+      "integrity": "sha512-9Ne4USX83nHmRuEYs78LW+3lFEEO2hBDHu7mrdIgAFx5Zcrs7ker3n/i8p4kf6OgKExmaDN5oR0efRD7i2J0DQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5675,12 +5805,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.76.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
-      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.3.tgz",
+      "integrity": "sha512-AqU8TvNh5GVIE8I+TUU0noryBRy7gOY0XhSayVXmOPll4UkZeLWKDwi0rtWOZbwLRCbyxorfJ5DIjDqE7GXpcQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.76.0"
+        "@tanstack/query-core": "5.85.3"
       },
       "funding": {
         "type": "github",
@@ -5902,23 +6032,25 @@
       }
     },
     "node_modules/@wagmi/connectors": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-5.8.3.tgz",
-      "integrity": "sha512-U4SJgi91+ny/XDGQWAMmawMafDx1BofcbYkPT/WSU6XrGL+apa7VltscqY7PVmwVGi/CYTqe8nlQiK/wmQ8D3A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-5.9.3.tgz",
+      "integrity": "sha512-HmSRFB3SFE1jAPs1E28I6/VOyA82i4KzC0OyG1JLEkOkyLlGsakPxtwXVdw/7kv9L4ppADWWktvwOjvhvpRmdQ==",
       "license": "MIT",
       "dependencies": {
-        "@coinbase/wallet-sdk": "4.3.0",
+        "@base-org/account": "1.1.1",
+        "@coinbase/wallet-sdk": "4.3.6",
+        "@gemini-wallet/core": "0.1.1",
         "@metamask/sdk": "0.32.0",
         "@safe-global/safe-apps-provider": "0.18.6",
         "@safe-global/safe-apps-sdk": "9.1.0",
-        "@walletconnect/ethereum-provider": "2.20.2",
+        "@walletconnect/ethereum-provider": "2.21.1",
         "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
       "peerDependencies": {
-        "@wagmi/core": "2.17.2",
+        "@wagmi/core": "2.19.0",
         "typescript": ">=5.0.4",
         "viem": "2.x"
       },
@@ -5929,15 +6061,19 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@coinbase/wallet-sdk": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.0.tgz",
-      "integrity": "sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
+      "integrity": "sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "^1.4.0",
-        "clsx": "^1.2.1",
-        "eventemitter3": "^5.0.1",
-        "preact": "^10.24.2"
+        "@noble/hashes": "1.4.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.27.2",
+        "zustand": "5.0.3"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@noble/curves": {
@@ -5955,7 +6091,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@wagmi/connectors/node_modules/@noble/hashes": {
+    "node_modules/@wagmi/connectors/node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
       "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
@@ -5967,54 +6103,79 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.3.tgz",
-      "integrity": "sha512-aA/UIwi/dVzxEB62xlw3qxHa3RK1YcPMjNxoGj/fHNCqL2qWmbcOXT7coCUa9RG7/Bh26FZ3vdVT2v71j6hebQ==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.8.tgz",
+      "integrity": "sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.3",
-        "@reown/appkit-controllers": "1.7.3",
-        "@reown/appkit-polyfills": "1.7.3",
-        "@reown/appkit-scaffold-ui": "1.7.3",
-        "@reown/appkit-ui": "1.7.3",
-        "@reown/appkit-utils": "1.7.3",
-        "@reown/appkit-wallet": "1.7.3",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/universal-provider": "2.19.2",
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-controllers": "1.7.8",
+        "@reown/appkit-pay": "1.7.8",
+        "@reown/appkit-polyfills": "1.7.8",
+        "@reown/appkit-scaffold-ui": "1.7.8",
+        "@reown/appkit-ui": "1.7.8",
+        "@reown/appkit-utils": "1.7.8",
+        "@reown/appkit-wallet": "1.7.8",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/universal-provider": "2.21.0",
         "bs58": "6.0.0",
         "valtio": "1.13.2",
-        "viem": ">=2.23.11"
+        "viem": ">=2.29.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-common": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.3.tgz",
-      "integrity": "sha512-wKTr6N3z8ly17cc51xBEVkZK4zAd8J1m7RubgsdQ1olFY9YJGe61RYoNv9yFjt6tUVeYT+z7iMUwPhX2PziefQ==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.8.tgz",
+      "integrity": "sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "big.js": "6.2.2",
         "dayjs": "1.11.13",
-        "viem": ">=2.23.11"
+        "viem": ">=2.29.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.3.tgz",
-      "integrity": "sha512-aqAcX/nZe0gwqjncyCkVrAk3lEw0qZ9xGrdLOmA207RreO4J0Vxu8OJXCBn4C2AUI2OpBxCPah+vyuKTUJTeHQ==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.8.tgz",
+      "integrity": "sha512-IdXlJlivrlj6m63VsGLsjtPHHsTWvKGVzWIP1fXZHVqmK+rZCBDjCi9j267Rb9/nYRGHWBtlFQhO8dK35WfeDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.3",
-        "@reown/appkit-wallet": "1.7.3",
-        "@walletconnect/universal-provider": "2.19.2",
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-wallet": "1.7.8",
+        "@walletconnect/universal-provider": "2.21.0",
         "valtio": "1.13.2",
-        "viem": ">=2.23.11"
+        "viem": ">=2.29.0"
+      }
+    },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.19.2.tgz",
-      "integrity": "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
+      "integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -6028,8 +6189,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0",
@@ -6040,26 +6201,26 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.19.2.tgz",
-      "integrity": "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
+      "integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.19.2",
+        "@walletconnect/core": "2.21.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.19.2.tgz",
-      "integrity": "sha512-/LZWhkVCUN+fcTgQUxArxhn2R8DF+LSd/6Wh9FnpjeK/Sdupx1EPS8okWG6WPAqq2f404PRoNAfQytQ82Xdl3g==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+      "integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -6071,9 +6232,9 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.19.2.tgz",
-      "integrity": "sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
+      "integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -6083,17 +6244,17 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.19.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/sign-client": "2.21.0",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "es-toolkit": "1.33.0",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.19.2.tgz",
-      "integrity": "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+      "integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "1.2.1",
@@ -6105,7 +6266,7 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
+        "@walletconnect/types": "2.21.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "bs58": "6.0.0",
@@ -6145,65 +6306,120 @@
         }
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit-controllers/node_modules/ox": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit-pay": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
+      "integrity": "sha512-OSGQ+QJkXx0FEEjlpQqIhT8zGJKOoHzVnyy/0QFrl3WrQTjCzg0L6+i91Ad5Iy1zb6V5JjqtfIFpRVRWN4M3pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-controllers": "1.7.8",
+        "@reown/appkit-ui": "1.7.8",
+        "@reown/appkit-utils": "1.7.8",
+        "lit": "3.3.0",
+        "valtio": "1.13.2"
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-polyfills": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.3.tgz",
-      "integrity": "sha512-vQUiAyI7WiNTUV4iNwv27iigdeg8JJTEo6ftUowIrKZ2/gtE2YdMtGpavuztT/qrXhrIlTjDGp5CIyv9WOTu4g==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.8.tgz",
+      "integrity": "sha512-W/kq786dcHHAuJ3IV2prRLEgD/2iOey4ueMHf1sIFjhhCGMynMkhsOhQMUH0tzodPqUgAC494z4bpIDYjwWXaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "6.0.3"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.3.tgz",
-      "integrity": "sha512-ssB15fcjmoKQ+VfoCo7JIIK66a4SXFpCH8uK1CsMmXmKIKqPN54ohLo291fniV6mKtnJxh5Xm68slGtGrO3bmA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.8.tgz",
+      "integrity": "sha512-RCeHhAwOrIgcvHwYlNWMcIDibdI91waaoEYBGw71inE0kDB8uZbE7tE6DAXJmDkvl0qPh+DqlC4QbJLF1FVYdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.3",
-        "@reown/appkit-controllers": "1.7.3",
-        "@reown/appkit-ui": "1.7.3",
-        "@reown/appkit-utils": "1.7.3",
-        "@reown/appkit-wallet": "1.7.3",
-        "lit": "3.1.0"
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-controllers": "1.7.8",
+        "@reown/appkit-ui": "1.7.8",
+        "@reown/appkit-utils": "1.7.8",
+        "@reown/appkit-wallet": "1.7.8",
+        "lit": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-ui": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.3.tgz",
-      "integrity": "sha512-zKmFIjLp0X24pF9KtPtSHmdsh/RjEWIvz+faIbPGm4tQbwcxdg9A35HeoP0rMgKYx49SX51LgPwVXne2gYacqQ==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.8.tgz",
+      "integrity": "sha512-1hjCKjf6FLMFzrulhl0Y9Vb9Fu4royE+SXCPSWh4VhZhWqlzUFc7kutnZKx8XZFVQH4pbBvY62SpRC93gqoHow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.3",
-        "@reown/appkit-controllers": "1.7.3",
-        "@reown/appkit-wallet": "1.7.3",
-        "lit": "3.1.0",
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-controllers": "1.7.8",
+        "@reown/appkit-wallet": "1.7.8",
+        "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.3.tgz",
-      "integrity": "sha512-8/MNhmfri+2uu8WzBhZ5jm5llofOIa1dyXDXRC/hfrmGmCFJdrQKPpuqOFYoimo2s2g70pK4PYefvOKgZOWzgg==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.8.tgz",
+      "integrity": "sha512-8X7UvmE8GiaoitCwNoB86pttHgQtzy4ryHZM9kQpvjQ0ULpiER44t1qpVLXNM4X35O0v18W0Dk60DnYRMH2WRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.3",
-        "@reown/appkit-controllers": "1.7.3",
-        "@reown/appkit-polyfills": "1.7.3",
-        "@reown/appkit-wallet": "1.7.3",
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-controllers": "1.7.8",
+        "@reown/appkit-polyfills": "1.7.8",
+        "@reown/appkit-wallet": "1.7.8",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/universal-provider": "2.19.2",
+        "@walletconnect/universal-provider": "2.21.0",
         "valtio": "1.13.2",
-        "viem": ">=2.23.11"
+        "viem": ">=2.29.0"
       },
       "peerDependencies": {
         "valtio": "1.13.2"
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.19.2.tgz",
-      "integrity": "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
+      "integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -6217,8 +6433,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0",
@@ -6229,26 +6445,26 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.19.2.tgz",
-      "integrity": "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
+      "integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.19.2",
+        "@walletconnect/core": "2.21.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.19.2.tgz",
-      "integrity": "sha512-/LZWhkVCUN+fcTgQUxArxhn2R8DF+LSd/6Wh9FnpjeK/Sdupx1EPS8okWG6WPAqq2f404PRoNAfQytQ82Xdl3g==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+      "integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -6260,9 +6476,9 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.19.2.tgz",
-      "integrity": "sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
+      "integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -6272,17 +6488,17 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.19.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/sign-client": "2.21.0",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "es-toolkit": "1.33.0",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.19.2.tgz",
-      "integrity": "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+      "integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "1.2.1",
@@ -6294,7 +6510,7 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
+        "@walletconnect/types": "2.21.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "bs58": "6.0.0",
@@ -6334,22 +6550,63 @@
         }
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit-utils/node_modules/ox": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit-wallet": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.3.tgz",
-      "integrity": "sha512-D0pExd0QUE71ursQPp3pq/0iFrz2oz87tOyFifrPANvH5X0RQCYn/34/kXr+BFVQzNFfCBDlYP+CniNA/S0KiQ==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
+      "integrity": "sha512-kspz32EwHIOT/eg/ZQbFPxgXq0B/olDOj3YMu7gvLEFz4xyOFd/wgzxxAXkp5LbG4Cp++s/elh79rVNmVFdB9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit-common": "1.7.3",
-        "@reown/appkit-polyfills": "1.7.3",
+        "@reown/appkit-common": "1.7.8",
+        "@reown/appkit-polyfills": "1.7.8",
         "@walletconnect/logger": "2.1.2",
         "zod": "3.22.4"
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/@walletconnect/core": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.19.2.tgz",
-      "integrity": "sha512-iu0mgLj51AXcKpdNj8+4EdNNBd/mkNjLEhZn6UMc/r7BM9WbmpPMEydA39WeRLbdLO4kbpmq4wTbiskI1rg+HA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
+      "integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -6363,8 +6620,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0",
@@ -6375,26 +6632,26 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.19.2.tgz",
-      "integrity": "sha512-a/K5PRIFPCjfHq5xx3WYKHAAF8Ft2I1LtxloyibqiQOoUtNLfKgFB1r8sdMvXM7/PADNPe4iAw4uSE6PrARrfg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
+      "integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.19.2",
+        "@walletconnect/core": "2.21.0",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/@walletconnect/types": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.19.2.tgz",
-      "integrity": "sha512-/LZWhkVCUN+fcTgQUxArxhn2R8DF+LSd/6Wh9FnpjeK/Sdupx1EPS8okWG6WPAqq2f404PRoNAfQytQ82Xdl3g==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+      "integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -6406,9 +6663,9 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.19.2.tgz",
-      "integrity": "sha512-LkKg+EjcSUpPUhhvRANgkjPL38wJPIWumAYD8OK/g4OFuJ4W3lS/XTCKthABQfFqmiNbNbVllmywiyE44KdpQg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
+      "integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -6418,17 +6675,17 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.19.2",
-        "@walletconnect/types": "2.19.2",
-        "@walletconnect/utils": "2.19.2",
+        "@walletconnect/sign-client": "2.21.0",
+        "@walletconnect/types": "2.21.0",
+        "@walletconnect/utils": "2.21.0",
         "es-toolkit": "1.33.0",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/@walletconnect/utils": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.19.2.tgz",
-      "integrity": "sha512-VU5CcUF4sZDg8a2/ov29OJzT3KfLuZqJUM0GemW30dlipI5fkpb0VPenZK7TcdLPXc1LN+Q+7eyTqHRoAu/BIA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+      "integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "1.2.1",
@@ -6440,7 +6697,7 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.19.2",
+        "@walletconnect/types": "2.21.0",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "bs58": "6.0.0",
@@ -6480,6 +6737,35 @@
         }
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@reown/appkit/node_modules/ox": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@scure/bip32": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
@@ -6489,6 +6775,18 @@
         "@noble/curves": "~1.8.1",
         "@noble/hashes": "~1.7.1",
         "@scure/base": "~1.2.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wagmi/connectors/node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6507,10 +6805,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/core": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.20.2.tgz",
-      "integrity": "sha512-48XnarxQQrpJ0KZJOjit56DxuzfVRYUdL8XVMvUh/ZNUiX2FB5w6YuljUUeTLfYOf04Et6qhVGEUkmX3W+9/8w==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.1.tgz",
+      "integrity": "sha512-Tp4MHJYcdWD846PH//2r+Mu4wz1/ZU/fr9av1UWFiaYQ2t2TPLDiZxjLw54AAEpMqlEHemwCgiRiAmjR1NDdTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -6524,8 +6834,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.20.2",
-        "@walletconnect/utils": "2.20.2",
+        "@walletconnect/types": "2.21.1",
+        "@walletconnect/utils": "2.21.1",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0",
@@ -6536,45 +6846,45 @@
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/ethereum-provider": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.20.2.tgz",
-      "integrity": "sha512-fGNJtytHuBWZcmMXRIG1djlfEiPMvPJ0R3JlfJjAx2VfVN+O+1xdF6QSWcZxFizviIUFJV+f1zWt0V2VVD61Rg==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.21.1.tgz",
+      "integrity": "sha512-SSlIG6QEVxClgl1s0LMk4xr2wg4eT3Zn/Hb81IocyqNSGfXpjtawWxKxiC5/9Z95f1INyBD6MctJbL/R1oBwIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@reown/appkit": "1.7.3",
+        "@reown/appkit": "1.7.8",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/sign-client": "2.20.2",
-        "@walletconnect/types": "2.20.2",
-        "@walletconnect/universal-provider": "2.20.2",
-        "@walletconnect/utils": "2.20.2",
+        "@walletconnect/sign-client": "2.21.1",
+        "@walletconnect/types": "2.21.1",
+        "@walletconnect/universal-provider": "2.21.1",
+        "@walletconnect/utils": "2.21.1",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/sign-client": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.20.2.tgz",
-      "integrity": "sha512-KyeDToypZ1OjCbij4Jx0cAg46bMwZ6zCKt0HzCkqENcex3Zchs7xBp9r8GtfEMGw+PUnXwqrhzmLBH0x/43oIQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.1.tgz",
+      "integrity": "sha512-QaXzmPsMnKGV6tc4UcdnQVNOz4zyXgarvdIQibJ4L3EmLat73r5ZVl4c0cCOcoaV7rgM9Wbphgu5E/7jNcd3Zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.20.2",
+        "@walletconnect/core": "2.21.1",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.20.2",
-        "@walletconnect/utils": "2.20.2",
+        "@walletconnect/types": "2.21.1",
+        "@walletconnect/utils": "2.21.1",
         "events": "3.3.0"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/utils": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.20.2.tgz",
-      "integrity": "sha512-2uRUDvpYSIJFYcr1WIuiFy6CEszLF030o6W8aDMkGk9/MfAZYEJQHMJcjWyaNMPHLJT0POR5lPaqkYOpuyPIQQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.1.tgz",
+      "integrity": "sha512-VPZvTcrNQCkbGOjFRbC24mm/pzbRMUq2DSQoiHlhh0X1U7ZhuIrzVtAoKsrzu6rqjz0EEtGxCr3K1TGRqDG4NA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "1.2.1",
@@ -6586,7 +6896,7 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.20.2",
+        "@walletconnect/types": "2.21.1",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "bs58": "6.0.0",
@@ -6594,6 +6904,47 @@
         "query-string": "7.1.3",
         "uint8arrays": "3.1.0",
         "viem": "2.23.2"
+      }
+    },
+    "node_modules/@wagmi/connectors/node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wagmi/connectors/node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/utils/node_modules/viem": {
@@ -6635,6 +6986,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@wagmi/connectors/node_modules/isows": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
@@ -6650,44 +7007,14 @@
         "ws": "*"
       }
     },
-    "node_modules/@wagmi/connectors/node_modules/lit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.0.tgz",
-      "integrity": "sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.1.0"
-      }
-    },
-    "node_modules/@wagmi/connectors/node_modules/ox": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
+    "node_modules/@wagmi/connectors/node_modules/preact": {
+      "version": "10.24.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
+      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
       "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.10.1",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip32": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
-        "abitype": "^1.0.6",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/qrcode": {
@@ -6717,10 +7044,39 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@wagmi/connectors/node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wagmi/core": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.17.2.tgz",
-      "integrity": "sha512-p1z8VU0YuRClx2bdPoFObDF7M2Reitz9AdByrJ+i5zcPCHuJ/UjaWPv6xD7ydhkWVK0hoa8vQ/KtaiEwEQS7Mg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.19.0.tgz",
+      "integrity": "sha512-lI57q6refAtNU6xnk/oyOpbEtEiwQ6g4rR+C9FEx8Gn2hZlfoyyksndrl6hIKlMBK+UkkKso3VwR5DI65j/5XQ==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "5.0.1",
@@ -7873,9 +8229,9 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.20.2.tgz",
-      "integrity": "sha512-XPPbJM/mGU05i6jUxhC3yI/YvhSF6TYJQ5SXTWM53lVe6hs6ukvlEhPctu9ZBTGwGFhwPXIjtK/eWx+v4WY5iw==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.1.tgz",
+      "integrity": "sha512-UeefNadqP6IyfwWC1Yi7ux+ljbP2R66PLfDrDm8izmvlPmYlqRerJWJvYO4t0Vvr9wrG4Ko7E0c4M7FaPKT/sQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -7887,9 +8243,9 @@
       }
     },
     "node_modules/@walletconnect/universal-provider": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.20.2.tgz",
-      "integrity": "sha512-6uVu1E88tioaXEEJCbJKwCIQlOHif1nmfY092BznZEnBn2lli5ICzQh2bxtUDNmNNLKsMDI3FV1fODFeWMVJTQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.1.tgz",
+      "integrity": "sha512-Wjx9G8gUHVMnYfxtasC9poGm8QMiPCpXpbbLFT+iPoQskDDly8BwueWnqKs4Mx2SdIAWAwuXeZ5ojk5qQOxJJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -7899,9 +8255,9 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
-        "@walletconnect/sign-client": "2.20.2",
-        "@walletconnect/types": "2.20.2",
-        "@walletconnect/utils": "2.20.2",
+        "@walletconnect/sign-client": "2.21.1",
+        "@walletconnect/types": "2.21.1",
+        "@walletconnect/utils": "2.21.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0"
       }
@@ -7961,9 +8317,9 @@
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.20.2.tgz",
-      "integrity": "sha512-48XnarxQQrpJ0KZJOjit56DxuzfVRYUdL8XVMvUh/ZNUiX2FB5w6YuljUUeTLfYOf04Et6qhVGEUkmX3W+9/8w==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.1.tgz",
+      "integrity": "sha512-Tp4MHJYcdWD846PH//2r+Mu4wz1/ZU/fr9av1UWFiaYQ2t2TPLDiZxjLw54AAEpMqlEHemwCgiRiAmjR1NDdTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -7977,8 +8333,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.20.2",
-        "@walletconnect/utils": "2.20.2",
+        "@walletconnect/types": "2.21.1",
+        "@walletconnect/utils": "2.21.1",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.33.0",
         "events": "3.3.0",
@@ -7989,26 +8345,26 @@
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/sign-client": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.20.2.tgz",
-      "integrity": "sha512-KyeDToypZ1OjCbij4Jx0cAg46bMwZ6zCKt0HzCkqENcex3Zchs7xBp9r8GtfEMGw+PUnXwqrhzmLBH0x/43oIQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.1.tgz",
+      "integrity": "sha512-QaXzmPsMnKGV6tc4UcdnQVNOz4zyXgarvdIQibJ4L3EmLat73r5ZVl4c0cCOcoaV7rgM9Wbphgu5E/7jNcd3Zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@walletconnect/core": "2.20.2",
+        "@walletconnect/core": "2.21.1",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.20.2",
-        "@walletconnect/utils": "2.20.2",
+        "@walletconnect/types": "2.21.1",
+        "@walletconnect/utils": "2.21.1",
         "events": "3.3.0"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.20.2.tgz",
-      "integrity": "sha512-2uRUDvpYSIJFYcr1WIuiFy6CEszLF030o6W8aDMkGk9/MfAZYEJQHMJcjWyaNMPHLJT0POR5lPaqkYOpuyPIQQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.1.tgz",
+      "integrity": "sha512-VPZvTcrNQCkbGOjFRbC24mm/pzbRMUq2DSQoiHlhh0X1U7ZhuIrzVtAoKsrzu6rqjz0EEtGxCr3K1TGRqDG4NA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "1.2.1",
@@ -8020,7 +8376,7 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.20.2",
+        "@walletconnect/types": "2.21.1",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "bs58": "6.0.0",
@@ -8886,9 +9242,9 @@
       "license": "MIT"
     },
     "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.0.tgz",
+      "integrity": "sha512-HcOcTudTeEWgbHh0Y1Tyb6fdeR71m4b/QACf0D4KswGTsNeIJQmg38mRENZPAYPZvGFN3fk3604XbQEPdxXdKg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -9885,20 +10241,32 @@
       }
     },
     "node_modules/eciesjs": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.14.tgz",
-      "integrity": "sha512-eJAgf9pdv214Hn98FlUzclRMYWF7WfoLlkS9nWMTm1qcCwn6Ad4EGD9lr9HXMBfSrZhYQujRE+p0adPRkctC6A==",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.15.tgz",
+      "integrity": "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==",
       "license": "MIT",
       "dependencies": {
-        "@ecies/ciphers": "^0.2.2",
-        "@noble/ciphers": "^1.0.0",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0"
+        "@ecies/ciphers": "^0.2.3",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.1",
+        "@noble/hashes": "^1.8.0"
       },
       "engines": {
         "bun": ">=1",
         "deno": ">=2",
         "node": ">=16"
+      }
+    },
+    "node_modules/eciesjs/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ecpair": {
@@ -12421,6 +12789,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -16167,13 +16541,13 @@
       }
     },
     "node_modules/wagmi": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.15.4.tgz",
-      "integrity": "sha512-0m7uo6t/oSFS+4UCUTBnmIhDSP7PGJz1qx4VtALcsBnw81UPPIXMSM8oGVrUNV9CptryiDgBlh4iYmRldg9iaA==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.16.3.tgz",
+      "integrity": "sha512-CJkt6e+PKM7sNQOVcExY2SWHoDNNMdS1L5q5gLujiu8Ngi6T2V4YlHj0Sm40nVC+NsW4MZOfscsx12FbVJ0iug==",
       "license": "MIT",
       "dependencies": {
-        "@wagmi/connectors": "5.8.3",
-        "@wagmi/core": "2.17.2",
+        "@wagmi/connectors": "5.9.3",
+        "@wagmi/core": "2.19.0",
         "use-sync-external-store": "1.4.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@divvi/referral-sdk": "^1.0.0",
     "@hookform/resolvers": "^5.1.1",
-    "@privy-io/react-auth": "^2.21.2",
+    "@privy-io/react-auth": "^2.21.3",
+    "@privy-io/wagmi": "^1.0.6",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
@@ -25,7 +26,7 @@
     "@radix-ui/react-switch": "^1.2.4",
     "@selfxyz/core": "^1.0.7-beta.1",
     "@selfxyz/qrcode": "^1.0.10-beta.1",
-    "@tanstack/react-query": "^5.76.1",
+    "@tanstack/react-query": "^5.85.3",
     "@tanstack/react-table": "^8.21.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/nodemailer": "^6.4.17",
@@ -54,7 +55,7 @@
     "uploadthing": "^7.7.2",
     "vaul": "^1.1.2",
     "viem": "^2.29.4",
-    "wagmi": "^2.15.4",
+    "wagmi": "^2.16.3",
     "zod": "^3.25.64"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgraded @privy-io/react-auth, @tanstack/react-query, wagmi, and related dependencies to their latest versions. Added @privy-io/wagmi and updated several peer and transitive dependencies to improve compatibility and security.