### PR TITLE
feat: Refactor fraction naming and add fleet lock period

### DIFF
--- a/components/fleet/garage.tsx
+++ b/components/fleet/garage.tsx
@@ -50,7 +50,7 @@ export function Garage() {
     const maxFleetOrderPerContainerQueryClient = useQueryClient() 
     const totalFleetOrderPerContainerQueryClient = useQueryClient()
     const lastFleetFractionQuerClient = useQueryClient()
-    const totalFractionsQueryClient = useQueryClient()
+    const totalSupplyQueryClient = useQueryClient()
     const { data: blockNumber } = useBlockNumber({ watch: true }) 
 
     // read balance of fleet owned
@@ -96,27 +96,27 @@ export function Garage() {
     }, [blockNumber, lastFleetFractionQuerClient, lastFleetFractionQueryKey]) 
     
     // read balance of total fraction
-    const { data: totalFractions, queryKey: totalFractionsQueryKey } = useReadContract({
+    const { data: totalSupply, queryKey: totalSupplyQueryKey } = useReadContract({
         address: fleetOrderBook,
         abi: fleetOrderBookAbi,
         functionName: "totalSupply",
         args: [lastFleetFractionID!]
     });
     useEffect(() => { 
-        totalFractionsQueryClient.invalidateQueries({ queryKey: totalFractionsQueryKey }) 
-    }, [blockNumber, totalFractionsQueryClient, totalFractionsQueryKey]) 
+        totalSupplyQueryClient.invalidateQueries({ queryKey: totalSupplyQueryKey }) 
+    }, [blockNumber, totalSupplyQueryClient, totalSupplyQueryKey]) 
 
     
     useEffect(() => {
-        if (totalFractions) {
-            const totalFractionsSold = Number(totalFractions) + ((Number(totalFleetOrderPerContainer) - 1) * 50)
+        if (totalSupply) {
+            const totalSupplySold = Number(totalSupply) + ((Number(totalFleetOrderPerContainer) - 1) * 50)
 
-            const totalFractionsAvailable = Number(maxFleetOrderPerContainer) * 50
+            const totalSupplyAvailable = Number(maxFleetOrderPerContainer) * 50
 
-            const value = (totalFractionsSold / totalFractionsAvailable) * 100
+            const value = (totalSupplySold / totalSupplyAvailable) * 100
             setProgress(value)
         }
-    }, [totalFractions, totalFleetOrderPerContainer, maxFleetOrderPerContainer])
+    }, [totalSupply, totalFleetOrderPerContainer, maxFleetOrderPerContainer])
     
     return (
         <div className="flex flex-col h-full w-full gap-6">
@@ -131,7 +131,7 @@ export function Garage() {
                             <Progress value={progress} className="w-full h-2" />
                             <div className="flex justify-between text-[0.7rem] text-[9px] text-muted-foreground">
                                 <span>{(progress?.toFixed(2))}% complete</span>
-                                <span>{Number(maxFleetOrderPerContainer) - Number(totalFleetOrderPerContainer)} units, {50 - Number(totalFractions)} fractions left</span>
+                                <span>{Number(maxFleetOrderPerContainer) - Number(totalFleetOrderPerContainer)} units, {50 - Number(totalSupply)} fractions left</span>
                             </div>
                         </div>
                     </AlertDescription>

--- a/components/fleet/id.tsx
+++ b/components/fleet/id.tsx
@@ -24,7 +24,8 @@ export function Id( {fleet}: IdProps ) {
 
     const isfleetFractionedQueryClient = useQueryClient()
     const fleetSharesQueryClient = useQueryClient()
-    const totalFractionsQueryClient = useQueryClient()
+    const fleetLockPeriodQueryClient = useQueryClient()
+    const totalSupplyQueryClient = useQueryClient()
     const fleetOrderStatusQueryClient = useQueryClient()
     const fleetFractionPriceQueryClient = useQueryClient()
     const { data: blockNumber } = useBlockNumber({ watch: true }) 
@@ -51,15 +52,25 @@ export function Id( {fleet}: IdProps ) {
     }, [blockNumber, fleetSharesQueryClient, fleetSharesQueryKey]) 
 
 
-    const { data: totalFractions, queryKey: totalFractionsQueryKey } = useReadContract({
+    const { data: totalSupply, queryKey: totalSupplyQueryKey } = useReadContract({
         address: fleetOrderBook,
         abi: fleetOrderBookAbi,
         functionName: "totalSupply",
         args: [BigInt(Number(fleet))],
     })
     useEffect(() => { 
-        totalFractionsQueryClient.invalidateQueries({ queryKey: totalFractionsQueryKey }) 
-    }, [blockNumber, totalFractionsQueryClient, totalFractionsQueryKey]) 
+        totalSupplyQueryClient.invalidateQueries({ queryKey: totalSupplyQueryKey }) 
+    }, [blockNumber, totalSupplyQueryClient, totalSupplyQueryKey]) 
+
+    const { data: fleetLockPeriod, queryKey: fleetLockPeriodQueryKey } = useReadContract({
+        address: fleetOrderBook,
+        abi: fleetOrderBookAbi,
+        functionName: "getFleetLockPeriodPerOrder",
+        args: [BigInt(Number(fleet))],
+    })
+    useEffect(() => { 
+        fleetLockPeriodQueryClient.invalidateQueries({ queryKey: fleetLockPeriodQueryKey }) 
+    }, [blockNumber, fleetLockPeriodQueryClient, fleetLockPeriodQueryKey]) 
 
 
     const { data: fleetOrderStatus, queryKey: fleetOrderStatusQueryKey } = useReadContract({
@@ -115,7 +126,7 @@ export function Id( {fleet}: IdProps ) {
                                     <div className="flex items-center gap-1">
                                         <span className="text-right font-bold">{fleetShares}</span>
                                         <span className="text-muted-foreground"> / </span>
-                                        <span className="text-right font-semibold italic">{totalFractions}</span>
+                                        <span className="text-right font-semibold italic">{totalSupply}</span>
                                         <span className="text-muted-foreground"> / </span>
                                         <span className="text-muted-foreground italic">50</span>
                                     </div>
@@ -128,7 +139,7 @@ export function Id( {fleet}: IdProps ) {
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="font-semibold">Yield Period:</span>
-                            <span className="text-right">60 weeks ~ 1 year</span>
+                            <span className="text-right">{Number(fleetLockPeriod)} weeks</span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="font-semibold">Start Date:</span>
@@ -136,7 +147,7 @@ export function Id( {fleet}: IdProps ) {
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="font-semibold">Weekly ROI:</span>
-                            <span className="text-right"><span className="font-bold text-muted-foreground" >$</span> {isfleetFractioned ? `${((( Number(fleetFractionPrice!) * Number(fleetShares!) ) * 1.75) / 60).toFixed(4)}` : `${(( (50 * Number(fleetFractionPrice!)) * 1.75 ) / 60).toFixed(4)}`}</span>
+                            <span className="text-right"><span className="font-bold text-muted-foreground" >$</span> {isfleetFractioned ? `${((( Number(fleetFractionPrice!) * Number(fleetShares!) ) * 1.75) / Number(fleetLockPeriod)).toFixed(4)}` : `${(( (50 * Number(fleetFractionPrice!)) * 1.75 ) / Number(fleetLockPeriod)).toFixed(4)}`}</span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="font-semibold">Total ROI <span className="text-muted-foreground italic text-yellow-800">(75%)</span>:</span>


### PR DESCRIPTION
Renamed variables and query clients from 'totalFractions' to 'totalSupply' for clarity in both garage.tsx and id.tsx. Added support for fetching and displaying the fleet lock period in id.tsx, updating the yield period and ROI calculations to use the dynamic lock period value.